### PR TITLE
complete antd setup:import antd css into index.css

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,15 @@
+@import "~antd/dist/antd.css";
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }


### PR DESCRIPTION
What I found out was that the problem was occurring because the setup of ant design required that the antd.css file was imported into the project.  So that is what was fixed. 

Implications: since this new addition of the ant-design styles is site-wide, it will affect all other ant-design components that were depending on its styling framework. For example, the look and feel of buttons. 

Kindly review and let me know if you have any feedback. Thanks 